### PR TITLE
Added cl-yaml as package name ans yaml ans nickname

### DIFF
--- a/src/yaml.lisp
+++ b/src/yaml.lisp
@@ -1,6 +1,7 @@
 (in-package :cl-user)
-(defpackage yaml
+(defpackage cl-yaml
   (:use :cl)
+  (:nicknames :yaml)
   (:export :parse
            :emit
            :emit-to-string)


### PR DESCRIPTION
Since the Quicklisp and Github names are `cl-yaml`, its natural to thing that the package name will be `cl-yaml` too.

Now one can add `cl-yaml` to the `:depends-on` `defsystem` list and to the `:import-from` `defpackage` list. Without it, one adds `cl-yaml` to `defsystem` but has to know/guess the name of the package.

With the `yaml` nickname, all code continues to work as it is.
